### PR TITLE
Fix save button not appearing on non-Standard leagues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,43 @@
 ## POE2 chrome extension for Save Filter for Path of Exile 2 trade site
 
-
 This extension adds a Save button to the Path of Exile 2 trade site. The button becomes active once a search is performed. If you're satisfied with the search results, you can choose to save the filter.
 
 Once saved, click on the extension icon to edit the filter's description to help you remember it. Then, simply click on Filter Link and you'll be redirected to the site with all your filters applied.
 
-This project is still under development and is open-source. You can check out the code on GitHub.
-
-Feel free to share your feedback with me at the email address provided below.
-
-Have fun and happy trading!
-
 If you don't see the button, refresh the page.
 
-The link to download the extension : <a href="https://chromewebstore.google.com/detail/poe2-save-trade-filter/nbnbkdemllokmclnniijkediimebjgho?authuser=0&hl=fr">Link</a>
+## Installation (Developer Mode)
+
+Since this fork is not published on Chrome Web Store, you can install it manually:
+
+### 1. Download the extension
+- [Download ZIP](https://github.com/gregoryderner/poe2-trade-save-filter/archive/refs/heads/fix/save-button-all-leagues.zip)
+- Extract the ZIP to a folder on your computer
+
+### 2. Enable Developer Mode in Chrome
+1. Open Chrome and go to `chrome://extensions/`
+2. Enable **Developer mode** (toggle in the top right corner)
+
+### 3. Load the extension
+1. Click **Load unpacked**
+2. Select the extracted folder (the one containing `manifest.json`)
+3. The extension should now appear in your extensions list
+
+### 4. Using the extension
+1. Go to [POE2 Trade Site](https://www.pathofexile.com/trade2)
+2. Configure your filters and click **Search**
+3. A green **Save Filter** button will appear
+4. Click it to save the filter
+5. Click the extension icon to view, edit, or access your saved filters
+
+### Updating the extension
+1. Download the latest ZIP and extract it (replacing old files)
+2. Go to `chrome://extensions/`
+3. Click the refresh icon on the extension card
+
+---
+
+**Original Chrome Web Store version:** [Link](https://chromewebstore.google.com/detail/poe2-save-trade-filter/nbnbkdemllokmclnniijkediimebjgho?authuser=0&hl=fr)
 
 <img src="https://github.com/LorenzoDv/poe2-trade-save-filter/blob/main/assets/img/savefilter1.png"> <br/><br/>
 <img src="https://github.com/LorenzoDv/poe2-trade-save-filter/blob/main/assets/img/savefilter2.png"> <br/><br/>

--- a/script.js
+++ b/script.js
@@ -1,27 +1,45 @@
+// Debug mode: true when extension is loaded unpacked (developer mode)
+const DEBUG = !('update_url' in chrome.runtime.getManifest());
+
+function debugLog(...args) {
+  if (DEBUG) {
+    console.log('[POE2 Save Filter]', ...args);
+  }
+}
+
+debugLog('Extension loaded (DEBUG MODE)');
 
 function waitForElements(selector, callback, timeout = 10000) {
+  debugLog('waitForElements: looking for', selector);
   const startTime = Date.now();
   const interval = setInterval(() => {
     const elements = document.querySelectorAll(selector);
     if (elements.length > 0) {
+      debugLog('waitForElements: FOUND', selector, elements);
       clearInterval(interval);
       callback(elements);
     }
     if (Date.now() - startTime > timeout) {
+      debugLog('waitForElements: TIMEOUT for', selector);
       clearInterval(interval);
     }
   }, 100);
 }
 
 waitForElements('.controls-center', (elements) => {
+  debugLog('controls-center callback triggered');
 
-  elements.forEach((targetDiv) => {
+  elements.forEach((targetDiv, index) => {
+    debugLog('Processing targetDiv', index, targetDiv);
     if (!targetDiv.querySelector('#save-filter-btn')) {
+      debugLog('No save-filter-btn found, setting up...');
       const btnSearch = document.querySelector('.search-btn');
       const btnClear = document.querySelector('.clear-btn');
+      debugLog('btnSearch:', btnSearch, 'btnClear:', btnClear);
       const saveButton = document.createElement('button');
 
       btnSearch.addEventListener('click', function () {
+        debugLog('Search button clicked!');
         
         saveButton.textContent = 'Save Filter';
         saveButton.id = 'save-filter-btn';
@@ -50,9 +68,12 @@ waitForElements('.controls-center', (elements) => {
     }
     const interval = setInterval(() => {
       const urlPath = window.location.href;
-      const regex = /\/Standard\/(.+)/;
+      const regex = /\/trade2\/search\/poe2\/[^\/]+\/(.+)/;
+      debugLog('Interval check - URL:', urlPath, 'Regex match:', regex.test(urlPath));
       if (regex.test(urlPath)) {
+        debugLog('URL matches! Checking for existing button...');
         if (!targetDiv.querySelector('#save-filter-btn')) {
+          debugLog('Creating Save Filter button!');
           const btnClear = document.querySelector('.clear-btn');
           const saveButton = document.createElement('button');
   
@@ -88,7 +109,9 @@ waitForElements('.controls-center', (elements) => {
           });
 
           if(!targetDiv.querySelector('#save-filter-btn')){
+            debugLog('Appending button to targetDiv');
             targetDiv.appendChild(saveButton);
+            debugLog('Button appended successfully!');
           }
          
           btnClear.addEventListener('click', function () {
@@ -104,9 +127,11 @@ waitForElements('.controls-center', (elements) => {
   });
 
   const targetNode = document.querySelector('.search-bar.search-advanced');
+  debugLog('MutationObserver targetNode:', targetNode);
 
-  
+
   const observer = new MutationObserver((mutationsList, observer) => {
+      debugLog('MutationObserver triggered, mutations:', mutationsList.length);
       for (let mutation of mutationsList) {
         const saveButton = document.getElementById('save-filter-btn');
         const btnSearch = document.querySelector('.search-btn');


### PR DESCRIPTION
## Summary
- Fix save button not appearing when using leagues other than Standard (e.g., Fate of the Vaal)
- Update URL regex to support all leagues dynamically
- Add debug logging system that only runs in developer mode (disabled in production)

## Problem
The save button was not appearing because the URL regex was hardcoded to only match `/Standard/` URLs. With the new league "Fate of the Vaal", the button would never show up.

## Solution
Changed the regex from `/\/Standard\/(.+)/` to `/\/trade2\/search\/poe2\/[^\/]+\/(.+)/` which matches any league name.

## Test plan
- [x] Load extension in developer mode
- [x] Navigate to POE2 trade site with non-Standard league
- [x] Perform a search
- [x] Verify "Save Filter" button appears
- [x] Verify debug logs appear in console (developer mode only)